### PR TITLE
Manually define jobname

### DIFF
--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     ref = os.environ["GITHUB_HEAD_REF"]
     repository_id = os.environ["GITHUB_REPOSITORY_ID"]
     run_id = os.environ["GITHUB_RUN_ID"]
-    run_number = os.environ["GITHUB_RUN_NUMBER"]
+    run_attempt = os.environ["GITHUB_RUN_ATTEMPT"]
 
     # user input
     config = json.loads(os.environ["INPUT_PANGEO_FORGE_RUNNER_CONFIG"])
@@ -56,7 +56,10 @@ if __name__ == "__main__":
         # FIXME: what if this is a push event, and not a pull_request event?
         pulls_url = "/".join([api_url, "repos", repository, "pulls"])
         print(f"Fetching pulls from {pulls_url}")
-        pulls = requests.get(pulls_url).json()
+        
+        pulls_response = requests.get(pulls_url)
+        pulls_response.raise_for_status()
+        pulls = pulls_response.json()
 
         for p in pulls:
             if p["head"]["ref"] == ref:
@@ -99,7 +102,7 @@ if __name__ == "__main__":
                 if len(rid) > 44:
                     print(f"Recipe id {rid} is > 44 chars, truncating to 44 chars.")
                 job_name = (
-                    f"{rid.lower().replace('_', '-')[:44]}-{repository_id}-{run_id}-{run_number}"
+                    f"{rid.lower().replace('_', '-')[:44]}-{repository_id}-{run_id}-{run_attempt}"
                 )
                 print(f"Submitting {job_name = }")
                 extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={job_name}"]

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
                 jobname = f"{rid}{workflow_sha}"
                 print(f"Submission {jobname = }")
                 extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={jobname}"]
-                print('Running PGF runner with {extrs_cmd = })
+                print(f"Running PGF runner with {extrs_cmd = }")
                 deploy_recipe_cmd(cmd + extra_cmd)
         else:
             deploy_recipe_cmd(cmd)

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -92,6 +92,10 @@ if __name__ == "__main__":
         print("\nSubmitting job...")
         if recipe_ids:
             for rid in recipe_ids:
-                deploy_recipe_cmd(cmd + [f"--Bake.recipe_id={rid}", f"--Bake.job_name={rid}{workflow_sha}"])
+                jobname = f"{rid}{workflow_sha}"
+                print(f"Submission {jobname = }")
+                extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={jobname}"]
+                print('Running PGF runner with {extrs_cmd = })
+                deploy_recipe_cmd(cmd + extra_cmd)
         else:
             deploy_recipe_cmd(cmd)

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
     server_url = os.environ["GITHUB_SERVER_URL"]
     api_url = os.environ["GITHUB_API_URL"]
     ref = os.environ["GITHUB_HEAD_REF"]
+    workflow_sha = os.environ["GITHUB_WORKFLOW_SHA"]
 
     # user input
     config = json.loads(os.environ["INPUT_PANGEO_FORGE_RUNNER_CONFIG"])
@@ -91,6 +92,6 @@ if __name__ == "__main__":
         print("\nSubmitting job...")
         if recipe_ids:
             for rid in recipe_ids:
-                deploy_recipe_cmd(cmd + [f"--Bake.recipe_id={rid}"])
+                deploy_recipe_cmd(cmd + [f"--Bake.recipe_id={rid}", f"--Bake.job_name={rid}{workflow_sha}"])
         else:
             deploy_recipe_cmd(cmd)

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -8,6 +8,7 @@ import requests
 
 
 def deploy_recipe_cmd(cmd: list[str]):
+    print(f"Calling subprocess with {cmd = }")
     submit_proc = subprocess.run(cmd, capture_output=True)
     stdout = submit_proc.stdout.decode()
     for line in stdout.splitlines():
@@ -31,7 +32,9 @@ if __name__ == "__main__":
     server_url = os.environ["GITHUB_SERVER_URL"]
     api_url = os.environ["GITHUB_API_URL"]
     ref = os.environ["GITHUB_HEAD_REF"]
-    workflow_sha = os.environ["GITHUB_WORKFLOW_SHA"]
+    repository_id = os.environ["GITHUB_REPOSITORY_ID"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    run_number = os.environ["GITHUB_RUN_NUMBER"]
 
     # user input
     config = json.loads(os.environ["INPUT_PANGEO_FORGE_RUNNER_CONFIG"])
@@ -93,11 +96,19 @@ if __name__ == "__main__":
         print(f"{recipe_ids = }")
         if recipe_ids:
             for rid in recipe_ids:
-                jobname = f"{rid}{workflow_sha[0:4]}"
-                jobname = jobname.lower().replace('_','')
-                print(f"Submission {jobname = }")
-                extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name=job{jobname}"]
-                print(f"Running PGF runner with {extra_cmd = }")
+                if len(rid) > 44:
+                    print(f"Recipe id {rid} is > 44 chars, truncating to 44 chars.")
+                job_name = (
+                    f"{rid.lower().replace('_', '-')[:44]}-{repository_id}-{run_id}-{run_number}"
+                )
+                print(f"Submitting {job_name = }")
+                extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={job_name}"]
                 deploy_recipe_cmd(cmd + extra_cmd)
         else:
+            # FIXME: pangeo-forge-runner handles job_name generation if we deploy everything
+            # currently, there is a pangeo-forge-runne bug that prevents creation of unique
+            # job_names when everything is deployed. apart from fixing that bug, we'd like the
+            # ability to provide our own job names, even if we deploy everything. this might mean
+            # passing a `--Bake.job_name_append` option to pangeo-forge-runner, which is a user-
+            # defined string to append to the job names.
             deploy_recipe_cmd(cmd)

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -93,10 +93,10 @@ if __name__ == "__main__":
         print(f"{recipe_ids = }")
         if recipe_ids:
             for rid in recipe_ids:
-                jobname = f"{rid}{workflow_sha}"
+                jobname = f"{rid}{workflow_sha[0:8]}"
                 print(f"Submission {jobname = }")
                 extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={jobname}"]
-                print(f"Running PGF runner with {extrs_cmd = }")
+                print(f"Running PGF runner with {extra_cmd = }")
                 deploy_recipe_cmd(cmd + extra_cmd)
         else:
             deploy_recipe_cmd(cmd)

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -90,6 +90,7 @@ if __name__ == "__main__":
             f.name,
         ]
         print("\nSubmitting job...")
+        print(f"{recipe_ids = }")
         if recipe_ids:
             for rid in recipe_ids:
                 jobname = f"{rid}{workflow_sha}"

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -93,9 +93,10 @@ if __name__ == "__main__":
         print(f"{recipe_ids = }")
         if recipe_ids:
             for rid in recipe_ids:
-                jobname = f"{rid}{workflow_sha[0:8]}"
+                jobname = f"{rid}{workflow_sha[0:4]}"
+                jobname = jobname.lower().replace('_','')
                 print(f"Submission {jobname = }")
-                extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name={jobname}"]
+                extra_cmd = [f"--Bake.recipe_id={rid}", f"--Bake.job_name=job{jobname}"]
                 print(f"Running PGF runner with {extra_cmd = }")
                 deploy_recipe_cmd(cmd + extra_cmd)
         else:


### PR DESCRIPTION
All dataflow jobs over in https://github.com/leap-stc/data-management/pull/19 where successfully deployed but failed shortly after with this message

```
Workflow failed. Causes: Unable to create directory: gs://leap-scratch/data-library/temp/gh-leap-stc-data-management-3107bcc-1683762190.1683762212.140912/dax-tmp-2023-05-10_16_43_37-1120618972252613873-S05-0-1419016091a5051e.
```

I suspect that it is an issue with the jobname (which determines the temp directory name). This is an attempt to provide a unique jobname based on the recipe id and the workflow sha.