### PR TITLE
Prevent deployment when `select_recipe_by_label` is true but no labels are set

### DIFF
--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         ]
         print("\nSubmitting job...")
         print(f"{recipe_ids = }")
-        if recipe_ids:
+        if select_recipe_by_label:
             for rid in recipe_ids:
                 if len(rid) > 44:
                     print(f"Recipe id {rid} is > 44 chars, truncating to 44 chars.")


### PR DESCRIPTION
Previously this would call pangeo-forge-runner without `Bake.recipe_id` (attempting to run all given recipes). 

This changes the behavior, so that when `select_recipe_by_label` is true, and the user e.g. pushes to main without labels, nothing should be deployed.