### PR TITLE
Upgrade pip in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # git is to support pip install from `git+https://` sources
 RUN apt-get update && apt-get install -y python3 python3-pip git
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install "pangeo-forge-runner>=0.9.2"
+RUN python3 -m pip install "pangeo-forge-runner[flink,dataflow]>=0.9.2"
 
 COPY action/deploy_recipe.py /deploy_recipe.py
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # git is to support pip install from `git+https://` sources
 RUN apt-get update && apt-get install -y python3 python3-pip git
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install "pangeo-forge-runner[flink,dataflow]>=0.9.2"
+RUN python3 -m pip install "pangeo-forge-runner>=0.9.2"
 
 COPY action/deploy_recipe.py /deploy_recipe.py
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 # git is to support pip install from `git+https://` sources
 RUN apt-get update && apt-get install -y python3 python3-pip git
+RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install "pangeo-forge-runner>=0.9.2"
 
 COPY action/deploy_recipe.py /deploy_recipe.py


### PR DESCRIPTION
Follow-on to #23.

Turns out without an upgraded pip, we can't install certain `git+` dependencies (presumably due to their packaging style, e.g. pyproject.toml vs setup.py).