### PR TITLE
WIP: Support multiple feedstock directories

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   pangeo_forge_runner_config:
     description: 'JSON configuration for Pangeo Forge Runner CLI.'
     required: true
+  auto_detect_feedstock_folders:
+    description: 'If passed as `True`, automatically detect feedstock folders in the repository.'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
   pangeo_forge_runner_config:
     description: 'JSON configuration for Pangeo Forge Runner CLI.'
     required: true
-  auto_detect_feedstock_folders:
+  autodetect_feedstock_folders:
     description: 'If passed as `True`, automatically detect feedstock folders in the repository.'
     required: false
 runs:

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -67,7 +67,7 @@ def main():
                 "one subdirectory in the repo contains a `meta.yaml` file."
             )
     else:
-        feedstock_subdirs = os.path.join(cwd, "feedstock")
+        feedstock_subdirs = [os.path.join(cwd, "feedstock")]
     print(f"{feedstock_subdirs = }")
 
     # parse config

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -63,8 +63,8 @@ def main():
         feedstock_subdirs = [f for f,_,files in os.walk(cwd) if 'meta.yaml' in files]
         if len(feedstock_subdirs) == 0:
             raise ValueError(
-                "No feedstock subdirectories found. Please confirm that at least one directory "
-                "in the repo contains a `meta.yaml` file."
+                "No feedstock subdirectories found. Please confirm that at least "
+                "one subdirectory in the repo contains a `meta.yaml` file."
             )
     else:
         feedstock_subdirs = os.path.join(cwd, "feedstock")
@@ -119,16 +119,16 @@ def main():
 
         recipe_ids = [l.replace("run:", "") for l in labels if l.startswith("run:")]
 
-        # dynamically install extra deps if requested.
-        # if calling `pangeo-forge-runner` directly, `--feedstock-subdir` can be passed as a CLI arg.
-        # in the action context, users do not compose their own `pangeo-forge-runner` CLI calls, so if
-        # they want to use a non-default value for feedstock-subdir, it must be passed via the long-form
-        # name in the config JSON (i.e, `{"BaseCommand": "feedstock_subdir": ...}}`).
-        feedstock_subdir = (
-            config["BaseCommand"]["feedstock_subdir"]
-            if "BaseCommand" in config and "feedstock_subdir" in config["BaseCommand"]
-            else "feedstock"
-        )
+        # # dynamically install extra deps if requested.
+        # # if calling `pangeo-forge-runner` directly, `--feedstock-subdir` can be passed as a CLI arg.
+        # # in the action context, users do not compose their own `pangeo-forge-runner` CLI calls, so if
+        # # they want to use a non-default value for feedstock-subdir, it must be passed via the long-form
+        # # name in the config JSON (i.e, `{"BaseCommand": "feedstock_subdir": ...}}`).
+        # feedstock_subdir = (
+        #     config["BaseCommand"]["feedstock_subdir"]
+        #     if "BaseCommand" in config and "feedstock_subdir" in config["BaseCommand"]
+        #     else "feedstock"
+        # )
         # because we've run the actions/checkout step before reaching this point, our current
         # working directory is the root of the feedstock repo, so we can list feedstock repo
         # contents directly on the filesystem here, without requesting it from github.

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -53,6 +53,8 @@ def main():
     config_string = os.environ["INPUT_PANGEO_FORGE_RUNNER_CONFIG"]
     select_recipe_by_label = os.environ["INPUT_SELECT_RECIPE_BY_LABEL"]
     autodetect_feedstock_folder = os.environ["INPUT_AUTODETECT_FEEDSTOCK_FOLDERS"]
+    print(f"{select_recipe_by_label = }")
+    print(f"{autodetect_feedstock_folder = }")
 
     cwd = os.getcwd()
 
@@ -61,6 +63,7 @@ def main():
         feedstock_subdirs = [f for f,_,files in os.walk(cwd) if 'meta.yaml' in files]
     else:
         feedstock_subdirs = os.path.join(cwd, "feedstock")
+    print(f"{feedstock_subdirs = }")
 
     # parse config
     print(f"pangeo-forge-runner-config provided as {config_string}")

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -61,6 +61,11 @@ def main():
     if autodetect_feedstock_folder:
         # find all folders that have a `meta.yaml` file in them
         feedstock_subdirs = [f for f,_,files in os.walk(cwd) if 'meta.yaml' in files]
+        if len(feedstock_subdirs) == 0:
+            raise ValueError(
+                "No feedstock subdirectories found. Please confirm that at least one directory "
+                "in the repo contains a `meta.yaml` file."
+            )
     else:
         feedstock_subdirs = os.path.join(cwd, "feedstock")
     print(f"{feedstock_subdirs = }")

--- a/action/deploy_recipe.py
+++ b/action/deploy_recipe.py
@@ -52,7 +52,7 @@ def main():
     # user input
     config_string = os.environ["INPUT_PANGEO_FORGE_RUNNER_CONFIG"]
     select_recipe_by_label = os.environ["INPUT_SELECT_RECIPE_BY_LABEL"]
-    autodetect_feedstock_folder = os.environ["INPUT_AUTODETECT_FEEDSTOCK_FOLDER"]
+    autodetect_feedstock_folder = os.environ["INPUT_AUTODETECT_FEEDSTOCK_FOLDERS"]
 
     cwd = os.getcwd()
 


### PR DESCRIPTION
Absolute WIP to support a reorganization of https://github.com/leap-stc/data-management

This would enable the user to just run the action over a bunch of subdir feedstocks (each one marked by the presence of a `meta.yaml` file) and still have fine grained control over which recipe is executed. 

The current implementation is just looping dumb over all subdirectories, but maybe there is a more clever way to quickly check all the meta.yaml files to see which of the feedstocks is actually tagged by the labels.